### PR TITLE
Logrotate changed su_owner to su_user

### DIFF
--- a/manifests/nextcloud.pp
+++ b/manifests/nextcloud.pp
@@ -73,7 +73,7 @@ class b2drop::nextcloud (
     create_owner  => $::apache::params::user,
     create_group  => $::apache::params::group,
     su            => true,
-    su_owner      => $::apache::params::user,
+    su_user       => $::apache::params::user,
     su_group      => $::apache::params::group,
   }
 }


### PR DESCRIPTION
We need to follow this change in order to use an up to date version of 
puppet-logrotate.